### PR TITLE
Using selected mode (dark, light) by default when userChoice is enabled

### DIFF
--- a/main.php
+++ b/main.php
@@ -21,25 +21,12 @@ $configUserChoice = tpl_getConf('userChoice');
 $configAutoDark = tpl_getConf('autoDark');
 $theme = tpl_getConf('theme');
 
-if ($configUserChoice) {
-
-    if (isset($_COOKIE["theme"])) {
-        $theme = $_COOKIE["theme"];
-    } 
-    else {
-        // If the cookie has never been set and both options are enabled, 
-        // then the auto mode will be used until the user makes a choice
-        if ($configAutoDark) {
-            $theme = "auto";
-        }
-        else {
-            $theme = "light";
-        } 
-    }
+if ($configAutoDark) {
+    $theme = "auto";
 }
 
-if ($configAutoDark and !$configUserChoice) {
-    $theme = "auto";
+if ($configUserChoice && isset($_COOKIE["theme"])) {
+    $theme = $_COOKIE["theme"];
 }
 
 // MindTheDark additional plugins


### PR DESCRIPTION
Hi! I propose a change in the logic that picks the color mode (light, dark) to use. It's simpler, and I think achieves the same behaviour as before, with an improvement for a specific case.

The following rules from the docs will still work:

> If the autoDark option is enabled, the color scheme of the operating system is used.
> If neither of the two options is selected, a static color scheme can be selected via theme.
> If both options are enabled, then Auto mode will be used until the user makes a choice. From this point on, only the user's choice is taken into account.

But also, this will happen now:
> If only `userChoice` is enabled, then the selected static mode will be used until the user makes a choice.

Which I believe works better than the current behavior (forcing light mode in that case until the user makes a choice).

This would close https://github.com/MrReSc/MindTheDark/issues/28.