### PR TITLE
Links in the sidebar should be displayed in the same way as the other links

### DIFF
--- a/css/design.less
+++ b/css/design.less
@@ -231,12 +231,6 @@ form.search {
         margin-bottom: 0;
         padding: 0;
     }
-
-    a:link,
-    a:visited {
-        color: var(--link, #2b73b7);
-        background-color: inherit;
-    }
 }
 
 [dir=rtl] .dokuwiki .aside ul,


### PR DESCRIPTION
Links to missing pages were displayed with the `--link` color instead of the `--missing` color in the sidebar.