### PR TITLE
Remove XSS possibility via `theme` cookie

### DIFF
--- a/detail.php
+++ b/detail.php
@@ -16,9 +16,9 @@ $theme = tpl_getConf('theme');
 
 if ($configUserChoice) {
 
-    if (isset($_COOKIE["theme"])) {
+    if (isset($_COOKIE["theme"]) && in_array($_COOKIE["theme"], array('light', 'dark'), true)) {
         $theme = $_COOKIE["theme"];
-    } 
+    }
     else {
         // If the cookie has never been set and both options are enabled, 
         // then the auto mode will be used until the user makes a choice

--- a/main.php
+++ b/main.php
@@ -25,7 +25,7 @@ if ($configAutoDark) {
     $theme = "auto";
 }
 
-if ($configUserChoice && isset($_COOKIE["theme"])) {
+if ($configUserChoice && isset($_COOKIE["theme"]) && in_array($_COOKIE["theme"], array('light', 'dark'), true)) {
     $theme = $_COOKIE["theme"];
 }
 


### PR DESCRIPTION
The `theme` cookie was echoed back into the html of the page without sanitization.